### PR TITLE
Add TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.json
 *.db
+*.key
+*.csr
+*.pem
 build/
 .DS_Store

--- a/cert/gen.sh
+++ b/cert/gen.sh
@@ -1,0 +1,9 @@
+rm *.pem
+rm *.csr
+rm *.key
+
+# Generate web server's private key and certificate signing request (CSR)
+openssl req -newkey rsa:4096 -nodes -keyout server.key -out server.csr -subj "/"
+
+# Self signe pem certificate with CSR
+openssl x509 -req -sha256 -days 365 -in server.csr -signkey server.key -out server.pem

--- a/pkg/infrastructure/port/secondary/client.go
+++ b/pkg/infrastructure/port/secondary/client.go
@@ -1,6 +1,8 @@
 package secondaryPort
 
 import (
+	"fmt"
+
 	"graft/pkg/domain"
 	"graft/pkg/infrastructure/adapter/p2pRpc"
 	adapter "graft/pkg/infrastructure/adapter/secondary"
@@ -70,6 +72,7 @@ func (p *rpcClientPort) PreVote(peer domain.Peer, input *domain.RequestVoteInput
 		LastLogTerm:  input.LastLogTerm,
 	})
 	if err != nil {
+		fmt.Println(err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Implements TLS with self signed server certificate.

Improvement:
- Should use mTLS instead with CA signed certificate

Self-signed TLS makes sense as Raft FSM should be hidden behind a proxy / not exposed to the internet. But it would be nice to have instead a self-signed CA and distribute the CA to each node to generate its own keys/certificates and use mTLS.

For now, TLS with self signed server certificate is secure enough for prototyping and development.